### PR TITLE
Deletes unnecessary parenthesis on regular expression [] clause.

### DIFF
--- a/Src/ZeroToNine/Versioning.fs
+++ b/Src/ZeroToNine/Versioning.fs
@@ -26,7 +26,7 @@ module Versioning =
         | _ ->
             Version(version.Major, version.Minor, version.Build, version.Revision + 1)
 
-    let private regx = Regex("""(^\s*[\[|<]<?\s*[a|A]ssembly\s*:\s*Assembly(File)?Version\s*\(\s*)"(\d+\.\d+\.\d+\.\d+)"(\s*\)\s*>?[\]|>]\s*$)""", RegexOptions.Compiled)
+    let private regx = Regex("""(^\s*[\[<]<?\s*[aA]ssembly\s*:\s*Assembly(File)?Version\s*\(\s*)"(\d+\.\d+\.\d+\.\d+)"(\s*\)\s*>?[\]>]\s*$)""", RegexOptions.Compiled)
     
     let TryParse text =
         let m = regx.Match text


### PR DESCRIPTION
References #10 comment tip and deletes the unnecessary parenthesis on regular expression clause.
