### PR TITLE
Support for assigning a particular Version to all AssemblyInfo files

### DIFF
--- a/Src/Zero29/Program.fs
+++ b/Src/Zero29/Program.fs
@@ -38,7 +38,7 @@ module Program =
             match Versioning.TryParse text with
             | None -> (text, None)
             | Some(pv) ->
-                let newVersion = Versioning.CreateVersion version
+                let newVersion = Version version
                 let newText = pv.ToString newVersion
                 let notification =
                     sprintf "Assigned %O %s from %O to %O"

--- a/Src/ZeroToNine.UnitTests/VersioningTests.fs
+++ b/Src/ZeroToNine.UnitTests/VersioningTests.fs
@@ -39,48 +39,6 @@ module VersioningTests =
 
         let expected = Version.Parse exp
         Assert.Equal(expected, actual)
-
-    [<Theory>]
-    [<InlineData("1.0.0.0")>]
-    [<InlineData("1.1.0.0")>]
-    [<InlineData("1.0.1.0")>]
-    [<InlineData("1.0.0.1")>]
-    [<InlineData("2.0.0.0")>]
-    [<InlineData("2.2.0.0")>]
-    [<InlineData("2.0.2.0")>]
-    [<InlineData("2.0.0.2")>]
-    [<InlineData("3.0.0.0")>]
-    [<InlineData("3.3.0.0")>]
-    [<InlineData("3.0.3.0")>]
-    [<InlineData("3.0.0.3")>]
-    [<InlineData("4.0.0.0")>]
-    [<InlineData("4.4.0.0")>]
-    [<InlineData("4.0.4.0")>]
-    [<InlineData("4.0.0.4")>]
-    [<InlineData("5.0.0.0")>]
-    [<InlineData("5.5.0.0")>]
-    [<InlineData("5.0.5.0")>]
-    [<InlineData("5.0.0.5")>]
-    [<InlineData("6.0.0.0")>]
-    [<InlineData("6.6.0.0")>]
-    [<InlineData("6.0.6.0")>]
-    [<InlineData("6.0.0.6")>]
-    [<InlineData("7.0.0.0")>]
-    [<InlineData("7.7.0.0")>]
-    [<InlineData("7.0.7.0")>]
-    [<InlineData("7.0.0.7")>]
-    [<InlineData("8.0.0.0")>]
-    [<InlineData("8.8.0.0")>]
-    [<InlineData("8.0.8.0")>]
-    [<InlineData("8.0.0.8")>]
-    [<InlineData("9.0.0.0")>]
-    [<InlineData("9.9.0.0")>]
-    [<InlineData("9.0.9.0")>]
-    [<InlineData("9.0.0.9")>]
-    let AssignVersionReturnsCorrectResult(version : string) = 
-        let actual = CreateVersion version
-        let expected = Version.Parse(version)
-        Assert.Equal(expected, actual)
     
     [<Theory>]
     [<InlineData("")>]

--- a/Src/ZeroToNine/Versioning.fs
+++ b/Src/ZeroToNine/Versioning.fs
@@ -14,9 +14,6 @@ module Versioning =
         Version : Version
         AttributeType : Type
         ToString : Version -> string }
-        
-    let CreateVersion version = 
-        Version(version)
 
     let IncrementVersion rank (version : Version) =
         match rank with


### PR DESCRIPTION
A new command, named _AssignVersion_, has been added to support the assignment of a particular Version to all AssemblyVersion and AssemblyFileVersion attributes, as described in #16.
